### PR TITLE
Add support for listing and loading profiles

### DIFF
--- a/OpenRGB.NET.Tests/OpenRGBClientUnits.cs
+++ b/OpenRGB.NET.Tests/OpenRGBClientUnits.cs
@@ -183,6 +183,15 @@ namespace OpenRGB.NET.Test
         }
 
         [Fact]
+        public void LoadRandomProfile()
+        {
+            OpenRGBClient client = new OpenRGBClient(name: "OpenRGB.NET Test: LoadRandomProfile");
+            var profiles = client.GetProfiles();
+            var loadMe = profiles[new Random().Next(0, profiles.Length)];
+            client.LoadProfile(loadMe);
+        }
+
+        [Fact]
         public void UseAfterDispose()
         {
             Stopwatch sw = Stopwatch.StartNew();

--- a/OpenRGB.NET/Enums/CommandId.cs
+++ b/OpenRGB.NET/Enums/CommandId.cs
@@ -26,6 +26,16 @@
         SetClientName = 50,
 
         /// <summary>
+        /// Request list of profiles from the server
+        /// </summary>
+        RequestProfiles = 150,
+
+        /// <summary>
+        /// Load a given profile
+        /// </summary>
+        LoadProfile = 152,
+
+        /// <summary>
         /// Calls RGBController::ResizeZone() on the server. Not implemented.
         /// </summary>
         ResizeZone = 1000,

--- a/OpenRGB.NET/IOpenRGBClient.cs
+++ b/OpenRGB.NET/IOpenRGBClient.cs
@@ -54,6 +54,18 @@ namespace OpenRGB.NET
         Device GetControllerData(int id);
 
         /// <summary>
+        /// Requests existing profiles on the server
+        /// </summary>
+        /// <returns>An array with profile names</returns>
+        string[] GetProfiles();
+
+        /// <summary>
+        /// Loads the provided profile on the server
+        /// </summary>
+        /// <param name="profile">Name of the profile to load</param>
+        void LoadProfile(string profile);
+
+        /// <summary>
         /// Sets the mode of the specified device to "Custom".
         /// </summary>
         /// <param name="deviceId"></param>

--- a/OpenRGB.NET/OpenRGBClient.cs
+++ b/OpenRGB.NET/OpenRGBClient.cs
@@ -207,8 +207,7 @@ namespace OpenRGB.NET
 
                 for (int i = 0; i < count; i++)
                 {
-                    var nameLength = reader.ReadUInt16();
-                    profiles[i] = Encoding.ASCII.GetString(reader.ReadBytes(nameLength));
+                    profiles[i] = reader.ReadLengthAndString();
                 }
 
                 return profiles;


### PR DESCRIPTION
Hey there, 

as mentioned in [this issue](https://github.com/diogotr7/OpenRGB.NET/issues/9), the SDK now supports profile management. This pull request adds support for listing all available profiles on the server and load a profile by its name. I don't have much of a use case for saving profiles via the SDK myself, so I left that part out.

Hope this works for you.