### PR TITLE
Clean TCP disconnect

### DIFF
--- a/OpenRGB.NET/OpenRGBClient.cs
+++ b/OpenRGB.NET/OpenRGBClient.cs
@@ -413,8 +413,15 @@ namespace OpenRGB.NET
                     // Managed object only
                     if (_socket != null && _socket.Connected)
                     {
-                        _socket?.Disconnect(false);
-                        _socket?.Dispose();
+                        try
+                        {
+                            socket?.Shutdown(SocketShutdown.Both);
+                        }
+                        finally
+                        {
+                            _socket?.Disconnect(false);
+                            _socket?.Dispose();
+                        }
                     }
                     disposed = true;
                 }

--- a/OpenRGB.NET/OpenRGBClient.cs
+++ b/OpenRGB.NET/OpenRGBClient.cs
@@ -415,12 +415,12 @@ namespace OpenRGB.NET
                     {
                         try
                         {
-                            socket?.Shutdown(SocketShutdown.Both);
-                        }
-                        finally
-                        {
-                            _socket?.Disconnect(false);
+                            _socket?.Shutdown(SocketShutdown.Both);
                             _socket?.Dispose();
+                        }
+                        catch
+                        {
+                            //Don't throw in Dispose
                         }
                     }
                     disposed = true;


### PR DESCRIPTION
Shutdown should be called before Disconnect on TCP sockets to ensure that data in the socket buffers have been sent.