### PR TITLE
Store ID numbers in Devices and Zones

### DIFF
--- a/OpenRGB.NET/Models/Device.cs
+++ b/OpenRGB.NET/Models/Device.cs
@@ -11,6 +11,11 @@ namespace OpenRGB.NET.Models
     public class Device
     {
         /// <summary>
+        /// The ID of the device.
+        /// </summary>
+        public int ID { get; private set; }
+
+        /// <summary>
         /// The type of the device.
         /// </summary>
         public DeviceType Type { get; private set; }
@@ -80,9 +85,12 @@ namespace OpenRGB.NET.Models
         /// </summary>
         /// <param name="buffer"></param>
         /// <param name="protocol"></param>
-        internal static Device Decode(byte[] buffer, uint protocol)
+        /// <param name="deviceId"></param>
+        internal static Device Decode(byte[] buffer, uint protocol, int deviceId)
         {
             var dev = new Device();
+            dev.ID = deviceId;
+
             using (var reader = new BinaryReader(new MemoryStream(buffer)))
             {
                 var duplicatePacketLength = reader.ReadUInt32();
@@ -121,7 +129,7 @@ namespace OpenRGB.NET.Models
                 dev.Modes = Mode.Decode(reader, modeCount);
 
                 var zoneCount = reader.ReadUInt16();
-                dev.Zones = Zone.Decode(reader, zoneCount);
+                dev.Zones = Zone.Decode(reader, zoneCount, deviceId);
 
                 var ledCount = reader.ReadUInt16();
                 dev.Leds = Led.Decode(reader, ledCount);

--- a/OpenRGB.NET/Models/Zone.cs
+++ b/OpenRGB.NET/Models/Zone.cs
@@ -11,6 +11,16 @@ namespace OpenRGB.NET.Models
     public class Zone
     {
         /// <summary>
+        /// The ID of the zone.
+        /// </summary>
+        public int ID { get; private set; }
+
+        /// <summary>
+        /// The ID of the zone's device
+        /// </summary>
+        public int DeviceID { get; private set; }
+
+        /// <summary>
         /// The name of the zone.
         /// </summary>
         public string Name { get; private set; }
@@ -46,13 +56,19 @@ namespace OpenRGB.NET.Models
         /// </summary>
         /// <param name="reader"></param>
         /// <param name="zoneCount"></param>
-        internal static Zone[] Decode(BinaryReader reader, ushort zoneCount)
+        /// <param name="deviceID"></param>
+        /// <param name="zoneID"></param>
+        internal static Zone[] Decode(BinaryReader reader, ushort zoneCount, int deviceID)
         {
             var zones = new Zone[zoneCount];
 
             for (int i = 0; i < zoneCount; i++)
             {
                 zones[i] = new Zone();
+
+                zones[i].DeviceID = deviceID;
+
+                zones[i].ID = i;
 
                 zones[i].Name = reader.ReadLengthAndString();
 

--- a/OpenRGB.NET/OpenRGBClient.cs
+++ b/OpenRGB.NET/OpenRGBClient.cs
@@ -176,7 +176,7 @@ namespace OpenRGB.NET
                 throw new ArgumentException(nameof(id));
 
             SendMessage(CommandId.RequestControllerData, BitConverter.GetBytes(ProtocolVersion), (uint)id);
-            return Device.Decode(ReadMessage(), ProtocolVersion);
+            return Device.Decode(ReadMessage(), ProtocolVersion, id);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Gives the zone objects some useful value for patterns like:

```
IEnumerable<Zone> zones = devices.SelectMany(dev => dev.Zones);
Zone longZone = zones.OrderByDescending(_ => _.LedCount).First();
client.UpdateZone(longZone.DeviceID, longZone.ID, someColors);
```

or

```
IEnumerable<Zone> singleZones = zones.Where(z => z.Type == ZoneType.Single);
foreach (Zone z in singleZones)
{
    client.UpdateZone(z.DeviceID, z.ID, new Color [] { Color.FromHsv(startTime / 36 + z.ID * 60, 1.0, 1.0) } );
}
```

I found I'm otherwise having to constantly work downwards from the Device[] returned by GetAllControllerData() and it's all for loops and indexing and manually managing ID numbers, which just feels very clumsy.

I intend to extend this out to something like `zone.Update(Color[] colors)` (just storing a reference to the client automatically passed down like the ID numbers and calling back to `client.UpdateZone`, I suppose?). This allows for much more intuitive and less-manually-managed interaction.

Reaching out for some feedback. I'm not much of C# guy, but it's a nice intersection of some of my needs at the moment.

Cheers,
Benny