### PR TITLE
fix DeviceListUpdated by passing OpenRgbClient instead of event

### DIFF
--- a/src/OpenRGB.NET/OpenRGB.NET.csproj
+++ b/src/OpenRGB.NET/OpenRGB.NET.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
-        <Version>3.1.1</Version>
+        <Version>3.1.2</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Authors>Diogo Trindade</Authors>

--- a/src/OpenRGB.NET/OpenRGBClient.cs
+++ b/src/OpenRGB.NET/OpenRGBClient.cs
@@ -47,7 +47,7 @@ public sealed class OpenRgbClient : IDisposable, IOpenRgbClient
         _name = name;
         _timeoutMs = timeoutMs;
         _protocolVersionNumber = protocolVersionNumber;
-        _connection = new OpenRgbConnection(DeviceListUpdated);
+        _connection = new OpenRgbConnection(this);
 
         if (protocolVersionNumber > MaxProtocolNumber)
             throw new ArgumentException("Client protocol version provided higher than supported.",
@@ -63,6 +63,11 @@ public sealed class OpenRgbClient : IDisposable, IOpenRgbClient
             return;
 
         _connection.Connect(_name, _ip, _port, _timeoutMs, _protocolVersionNumber);
+    }
+
+    internal void OnDeviceListUpdated()
+    {
+        DeviceListUpdated?.Invoke(this, EventArgs.Empty);
     }
 
     #region API

--- a/src/OpenRGB.NET/OpenRgbConnection.cs
+++ b/src/OpenRGB.NET/OpenRgbConnection.cs
@@ -23,9 +23,9 @@ internal sealed class OpenRgbConnection : IDisposable
 
     public ProtocolVersion CurrentProtocolVersion { get; private set; }
 
-    public EventHandler<EventArgs>? DeviceListUpdated { get; set; }
+    private OpenRgbClient Client { get; }
 
-    public OpenRgbConnection(EventHandler<EventArgs>? OnDeviceListUpdated)
+    public OpenRgbConnection(OpenRgbClient openRgbClient)
     {
         _cancellationTokenSource = new CancellationTokenSource();
         _socket = new Socket(SocketType.Stream, ProtocolType.Tcp);
@@ -33,7 +33,7 @@ internal sealed class OpenRgbConnection : IDisposable
         _pendingRequests = Enum.GetValues(typeof(CommandId)).Cast<CommandId>()
             .ToDictionary(c => c, _ => new BlockingCollection<byte[]>());
 
-        DeviceListUpdated = OnDeviceListUpdated;
+        Client = openRgbClient;
     }
 
     public void Connect(string name, string ip, int port, int timeoutMs, uint protocolVersionNumber = 4)
@@ -67,7 +67,7 @@ internal sealed class OpenRgbConnection : IDisposable
                     {
                         try
                         {
-                            DeviceListUpdated?.Invoke(this, EventArgs.Empty);
+                            Client.OnDeviceListUpdated();
                         }
                         catch
                         {


### PR DESCRIPTION
There seems to be a stale reference after the initialization and the even doesn't trigger in current state